### PR TITLE
S3 upload url view

### DIFF
--- a/gym_server/gym_server/settings/common.py
+++ b/gym_server/gym_server/settings/common.py
@@ -131,3 +131,7 @@ SOCIALACCOUNT_PROVIDERS = {
 }
 
 SITE_ID = 3
+
+
+# upload specific stuff
+S3_EVALUATION_BUCKET = os.environ.get('S3_EVALUATION_BUCKET', 'evaluations')

--- a/gym_server/gym_server/urls.py
+++ b/gym_server/gym_server/urls.py
@@ -18,7 +18,7 @@ from django.urls import re_path
 from django.contrib import admin
 from environments.views import EnvironmentViewSet
 from rest_framework import routers
-from scoreboards.views import EvaluationRunViewSet
+from scoreboards.views import EvaluationRunViewSet, S3UploadURLView
 
 
 # register environment router
@@ -34,4 +34,5 @@ urlpatterns = [
     url(r'^auth/', include('authentication.urls')),
     url(r'^environments/', include(environment_router.urls)),
     url(r'^evaluations/', include(eval_router.urls)),
+    url(r'^url-sign-request/', S3UploadURLView.as_view()),
 ]

--- a/gym_server/scoreboards/serializers.py
+++ b/gym_server/scoreboards/serializers.py
@@ -13,12 +13,13 @@ class EvaluationRunSerializer(serializers.ModelSerializer):
         depth = 1
 
 
-class ScoreBoardSerializer(serializers.ModelSerializer):
+class S3UploadURLSerializer(serializers.Serializer):
     '''
-    This class implements the `ModelSerializer` for the gym-server scoreboard.
-    Basically, it is a `EvaluationRunSerializer` with modified fields, as we don't
-    need to send along the `env` field with every request.
+    The `S3UploadURLSerializer` provides de/serializing functionality for the
+    pre-signed upload URL we provide to each client.
     '''
+    url = serializers.URLField(max_length=255, read_only=True)
+
     class Meta:
         model = EvaluationRun
         fields = ('pk', 'user', 's3_path', 'high_score')

--- a/gym_server/scoreboards/tests/test_serializers.py
+++ b/gym_server/scoreboards/tests/test_serializers.py
@@ -1,1 +1,1 @@
-from scoreboards.serializers import EvaluationRunSerializer, ScoreBoardSerializer
+from scoreboards.serializers import EvaluationRunSerializer

--- a/gym_server/scoreboards/tests/test_views.py
+++ b/gym_server/scoreboards/tests/test_views.py
@@ -1,1 +1,30 @@
-from scoreboards.views import EvaluationRunViewSet
+from allauth.socialaccount.models import SocialToken
+from mixer.backend.django import mixer
+from rest_framework import status
+from rest_framework.test import force_authenticate, APITestCase
+from scoreboards.views import EvaluationRunViewSet, S3UploadURLView
+
+
+class S3UploadURLViewTest(APITestCase):
+    '''
+    This test suite ensures that the `S3UploadURLView` works as follows:
+    - In case the client is not authenticated, we reject the request
+      sending an HTTP 401 response
+    - In case the client is authenticated, but no user is associated with
+      the current `SocialToken`, we respond with an HTTP 400 response
+    - Else, we send an HTTP 200 response with an `url` key containing the
+      url.
+    '''
+    def test_rejects_unauthenticated_user(self):
+        resp = self.client.get('/url-sign-request/')
+        self.assertEqual(resp.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_sends_400_if_user_not_found(self):
+        resp = self.client.get('/url-sign-request/?token=test-test')
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_url_signed_correctly_if_user_exists(self):
+        token = mixer.blend(SocialToken)
+        resp = self.client.get('/url-sign-request/?token={}'.format(token.token))
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertIsNotNone(resp.data.get('url', None))

--- a/gym_server/scoreboards/views.py
+++ b/gym_server/scoreboards/views.py
@@ -61,13 +61,9 @@ class S3UploadURLView(APIView):
         datetime_str = datetime.utcnow().strftime('%Y_%m_%d_%H_%M_%S')
         key = '{}/eval_{}'.format(account.uid, datetime_str)
 
-        # handle URL signing via boto3
-        try:
-            url = self.s3_connection\
-                .generate_url(3600, 'PUT', key=key, bucket=settings.S3_EVALUATION_BUCKET)
-        except Exception as e:
-            print('Something happened here: {}'.format(str(e)))
-            return Response({'meeehe': 'meeeeh'}, status.HTTP_500_INTERNAL_SERVER_ERROR)
+        # sign URL via boto
+        url = self.s3_connection\
+            .generate_url(3600, 'PUT', key=key, bucket=settings.S3_EVALUATION_BUCKET)
 
         # return serialized response
         serializer = S3UploadURLSerializer({'url': url})

--- a/gym_server/scoreboards/views.py
+++ b/gym_server/scoreboards/views.py
@@ -1,5 +1,7 @@
 # -*- coding: utf-8 -*-
 from __future__ import unicode_literals
+from allauth.socialaccount.models import SocialAccount, SocialToken
+from datetime import datetime
 from environments.models import Environment
 from rest_framework import status, viewsets
 from rest_framework.response import Response
@@ -15,3 +17,35 @@ class EvaluationRunViewSet(viewsets.ReadOnlyModelViewSet):
     '''
     serializer_class = EvaluationRunSerializer
     queryset = EvaluationRun.objects.all()
+
+
+class S3UploadURLView(APIView):
+    '''
+    This view is used by the client to retrieve a presigned upload URL,
+    which it uses to upload its training evaluation to our bucket. Following our
+    convention, our upload path inside the bucket is composed of the datetime string
+    prefixed by the client uid.
+
+    The actual signing is facilitated by the boto3 library, which provides
+    this functionality out of the box. More, we do not need to pass in any
+    credentials as we enable this functionality on an EC2 role basis.
+    '''
+    def get(self, request):
+        if request.GET.get('token', None) is None:
+            return Response({'error': 'auth token missing'},
+                            status=status.HTTP_401_UNAUTHORIZED)
+
+        auth_token = request.GET.get('token')
+
+        # get social account
+        try:
+            account = SocialAccount.objects.get(socialtoken__token=auth_token)
+        except SocialAccount.DoesNotExist:
+            return Response({'error': 'no associated account found'},
+                            status=status.HTTP_400_BAD_REQUEST)
+
+        # build upload url: {social account uid}/eval_{datetime string}
+        datetime_str = datetime.utcnow().strftime('%Y_%m_%d_%H_%M_%S')
+        upload_path = '{}/eval_{}'.format(account.uid, datetime_str)
+
+        # handle URL signing via boto3


### PR DESCRIPTION
This PR introduces a new endpoint reachable at `sign-url-request/`, which handles the upload url signing process necessary to obtain a valid upload URL for the private evaluation bucket.

First of all, it is of utmost importance to introduce a consistent upload url scheme. At this point, I'd like to introduce the following:
To keep our bucket data as anonymous as possible, I propose to use `allauth.socialaccount.SocialAccount`'s `uid` prop as the folder name, which holds all evaluations of any given user. Further, to keep it nice and clean, any evaluation is uploaded into a separate folder, which is composed of a `UTC` datetime string prefixed by `eval_`. 


The view named `S3UploadURLView` handles incoming `GET` requests as follows:

1. First, it checks, whether a query param called `token` is present and sends a `UNAUTHORIZED` response code in case it's missing.
2. Then, it tries to retrieve the `SocialAccount`, whose `SocialToken` matches the `token` query param. In case it fails to, it sends a `BAD REQUEST` response code.
3. Finally, it generates and signs an upload url utilising the `boto` library and returns it as the `url` property of the response body. All generated upload urls follow the schema proposed above.