### PR TITLE
Custom User Details Serializer

### DIFF
--- a/gym_server/authentication/serializers.py
+++ b/gym_server/authentication/serializers.py
@@ -1,0 +1,13 @@
+from rest_auth.serializers import UserDetailsSerializer
+from rest_framework import serializers
+
+
+class OpenRLAccountSerializer(UserDetailsSerializer):
+    '''
+    Adds `auth_token` field to `SocialAccountSerializer`
+    '''
+    auth_token = serializers.ReadOnlyField(source='openrl_token.token')
+
+    class Meta:
+        model = UserDetailsSerializer.Meta.model
+        fields = UserDetailsSerializer.Meta.fields + ('auth_token',)

--- a/gym_server/authentication/tests/test_serializers.py
+++ b/gym_server/authentication/tests/test_serializers.py
@@ -1,0 +1,1 @@
+from authentication.serializers import OpenRLAccountSerializer


### PR DESCRIPTION
The new serializer is subclassed from `rest_auth`s `UserDetailsSerializer` and extends its parent by a `auth_token` field, which corresponds to our custom `AuthToken` model.