### PR TITLE
Fix/auth token autogen

### DIFF
--- a/gym_server/authentication/__init__.py
+++ b/gym_server/authentication/__init__.py
@@ -1,0 +1,1 @@
+default_app_config = 'authentication.apps.AuthenticationConfig'

--- a/gym_server/authentication/apps.py
+++ b/gym_server/authentication/apps.py
@@ -3,3 +3,6 @@ from django.apps import AppConfig
 
 class AuthenticationConfig(AppConfig):
     name = 'authentication'
+
+    def ready(self):
+        import authentication.receiver

--- a/gym_server/authentication/receiver.py
+++ b/gym_server/authentication/receiver.py
@@ -1,4 +1,4 @@
-from allauth.socialaccount.signals import social_account_added
+from allauth.account.signals import user_signed_up
 from authentication.models import AuthToken
 from authentication.utils import generate_unique_auth_token
 
@@ -9,10 +9,10 @@ def generate_auth_token(request, sociallogin, **kwargs):
     signal and generates a new auth token for the user. This is facilitated by
     hashing the user's username and the account creation time.
     '''
-    account = sociallogin.user.user
+    account = sociallogin.user
     token = generate_unique_auth_token()
 
     AuthToken.objects.create(account=account, token=token)
 
 
-social_account_added.connect(generate_auth_token, dispatch_uid='generate_token')
+user_signed_up.connect(generate_auth_token, dispatch_uid='generate_token')


### PR DESCRIPTION
This PR addresses #22 by implementing a `ready` method for `AuthenticationConfig` class and importing `authentication.receiver` within the procedure. What's more, `AuthenticationConfig` is declared as `default_app_config` in `authentication.__init__`, which fixes the bug.