### PR TITLE
Fix/gh login

### DIFF
--- a/gym_server/authentication/urls.py
+++ b/gym_server/authentication/urls.py
@@ -13,9 +13,13 @@ Including another URLconf
     1. Add an import:  from blog import urls as blog_urls
     2. Add a URL to urlpatterns:  url(r'^blog/', include(blog_urls))
 '''
+from allauth.account.views import confirm_email
 from authentication.views import GithubLoginView
-from django.conf.urls import url
+from django.conf.urls import url, include
 
 urlpatterns = [
-    url(r'github/$', GithubLoginView.as_view(), name='github_login')
+    url(r'github/$', GithubLoginView.as_view(), name='github_login'),
+    url(r"^confirm-email/(?P<key>[-:\w]+)/$", confirm_email,
+        name="account_confirm_email"),
+    url(r'', include('rest_auth.urls')),
 ]

--- a/gym_server/authentication/views.py
+++ b/gym_server/authentication/views.py
@@ -1,4 +1,6 @@
 from allauth.socialaccount.providers.github.views import GitHubOAuth2Adapter
+from allauth.socialaccount.providers.oauth2.client import OAuth2Client
+from django.conf import settings
 from rest_auth.registration.serializers import SocialLoginSerializer
 from rest_auth.registration.views import SocialLoginView
 
@@ -6,3 +8,5 @@ from rest_auth.registration.views import SocialLoginView
 class GithubLoginView(SocialLoginView):
     serializer_class = SocialLoginSerializer
     adapter_class = GitHubOAuth2Adapter
+    client_class = OAuth2Client
+    callback_url = settings.AUTH_CALLBACK_URL

--- a/gym_server/gym_server/settings/common.py
+++ b/gym_server/gym_server/settings/common.py
@@ -84,7 +84,6 @@ WSGI_APPLICATION = 'gym_server.wsgi.application'
 
 # Database
 # https://docs.djangoproject.com/en/1.8/ref/settings/#databases
-
 DATABASES = {
     'default': {
         'ENGINE': 'django.db.backends.sqlite3',
@@ -95,7 +94,6 @@ DATABASES = {
 
 # Internationalization
 # https://docs.djangoproject.com/en/1.8/topics/i18n/
-
 LANGUAGE_CODE = 'en-us'
 
 TIME_ZONE = 'UTC'
@@ -119,7 +117,7 @@ REST_FRAMEWORK = {
 }
 
 
-# social login
+# social login related settings
 SOCIALACCOUNT_PROVIDERS = {
     'github': {
         'SCOPE': [
@@ -129,6 +127,15 @@ SOCIALACCOUNT_PROVIDERS = {
         ],
     }
 }
+
+AUTH_CALLBACK_URL = os.environ.get('AUTH_CALLBACK_URL', 'http://localhost:8000')
+
+
+# rest auth serializer config
+REST_AUTH_SERIALIZERS = {
+    'USER_DETAILS_SERIALIZER': 'authentication.serializers.OpenRLAccountSerializer',
+}
+
 
 SITE_ID = 3
 

--- a/gym_server/gym_server/settings/common.py
+++ b/gym_server/gym_server/settings/common.py
@@ -105,10 +105,13 @@ USE_L10N = True
 USE_TZ = True
 
 
+# Email
+EMAIL_BACKEND = 'django.core.mail.backends.console.EmailBackend'
+
 # Static files (CSS, JavaScript, Images)
 # https://docs.djangoproject.com/en/1.8/howto/static-files/
-
 STATIC_URL = '/static/'
+
 
 # pagination
 REST_FRAMEWORK = {


### PR DESCRIPTION
Addresses #24 
This PR fixes the broken github login by implementing the following:

1. `client_class` and `callback_url` for `GithubLoginView`. `callback_url` is imported from `settings` and is configurable by the `AUTH_CALLBACK_URL` environment variable, defaulting to `http://localhost:8000`
2. Adds a console email backend to `common.py`

Additionally, some url conf cleanup has been done